### PR TITLE
Persist prompt history in localStorage

### DIFF
--- a/index.html
+++ b/index.html
@@ -276,8 +276,17 @@
       })
       .catch(err => console.error('Failed to load prompts:', err));
 
-    // Initialize prompt history as an in-memory array instead of using localStorage
+    // Load prompt history from localStorage so it persists across sessions
     let promptHistory = [];
+    try {
+      const storedHistory = localStorage.getItem('promptHistory');
+      if (storedHistory) {
+        promptHistory = JSON.parse(storedHistory);
+      }
+    } catch (e) {
+      console.error('Failed to parse history from localStorage:', e);
+      promptHistory = [];
+    }
     
     // Display history items
     function updateHistoryDisplay() {
@@ -322,6 +331,7 @@
         if (!promptHistory.includes(randomPrompt)) {
           promptHistory.unshift(randomPrompt);
           promptHistory = promptHistory.slice(0, 5); // Keep only 5 items
+          localStorage.setItem('promptHistory', JSON.stringify(promptHistory));
           updateHistoryDisplay();
         }
         


### PR DESCRIPTION
## Summary
- load saved prompt history from `localStorage`
- save new history entries back to `localStorage`

## Testing
- `python3 sanitize_prompts.py`

------
https://chatgpt.com/codex/tasks/task_e_6847eec877ec832fae0050287314f8d1