### PR TITLE
Add args to sanitize script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@ The page will keep a short history of previously generated prompts during your s
 
 If you want to change the set of prompts, edit `hellPrompts.json` and reload `index.html`. The page will automatically use your updated prompt list.
 
+### Sanitizing Prompts
+
+Use `sanitize_prompts.py` to remove control characters from your prompt list.
+
+```
+python sanitize_prompts.py
+```
+
+By default it reads from `hellPrompts.json` and writes the cleaned prompts back to the same file. You can specify custom input and output files:
+
+```
+python sanitize_prompts.py -i my_prompts.json -o cleaned.json
+```
+
 ## License
 
 This project is distributed under the [Apache License 2.0](LICENSE).

--- a/sanitize_prompts.py
+++ b/sanitize_prompts.py
@@ -1,18 +1,22 @@
+import argparse
 import json
-import sys
 import re
 
 CONTROL_CHARS = ''.join(chr(i) for i in range(32)) + chr(127)
 control_re = re.compile('[%s]' % re.escape(CONTROL_CHARS))
 
-with open('hellPrompts.json', 'r', encoding='utf-8') as f:
+parser = argparse.ArgumentParser(description="Remove control characters from a JSON list of prompts")
+parser.add_argument('-i', '--input', default='hellPrompts.json', help='Input JSON file')
+parser.add_argument('-o', '--output', default='hellPrompts.json', help='Output JSON file')
+args = parser.parse_args()
+
+with open(args.input, 'r', encoding='utf-8') as f:
     data = json.load(f)
 
 cleaned = [control_re.sub('', item) for item in data]
 
-with open('hellPrompts.json', 'w', encoding='utf-8') as f:
+with open(args.output, 'w', encoding='utf-8') as f:
     json.dump(cleaned, f, ensure_ascii=False, indent=2)
     f.write('\n')
 
 print('Removed control characters from %d prompts.' % len(data))
-


### PR DESCRIPTION
## Summary
- make `sanitize_prompts.py` accept optional input/output paths via `argparse`
- document how to use the script with new options in README

## Testing
- `python -m py_compile sanitize_prompts.py`
- `python sanitize_prompts.py --input hellPrompts.json --output hellPrompts.json`

------
https://chatgpt.com/codex/tasks/task_e_6847eecbd8f0832f81b3423a46f9fb4a