### PR TITLE
Update sanitize defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ Prompts are stored in JSON files named `hellPrompts.<lang>.json`. Edit `hellProm
 
 ### Sanitizing prompt files
 
-Remove control characters after editing to keep the data clean:
+Remove control characters after editing to keep the data clean. By default the
+script reads and writes `hellPrompts.en.json`:
 
 ```bash
-python sanitize_prompts.py -i hellPrompts.en.json -o hellPrompts.en.json
+python sanitize_prompts.py
 ```
 
 ### Translating prompt files

--- a/sanitize_prompts.py
+++ b/sanitize_prompts.py
@@ -6,8 +6,10 @@ CONTROL_CHARS = ''.join(chr(i) for i in range(32)) + chr(127)
 control_re = re.compile('[%s]' % re.escape(CONTROL_CHARS))
 
 parser = argparse.ArgumentParser(description="Remove control characters from a JSON list of prompts")
-parser.add_argument('-i', '--input', default='hellPrompts.json', help='Input JSON file')
-parser.add_argument('-o', '--output', default='hellPrompts.json', help='Output JSON file')
+parser.add_argument('-i', '--input', default='hellPrompts.en.json',
+                    help='Input JSON file')
+parser.add_argument('-o', '--output', default='hellPrompts.en.json',
+                    help='Output JSON file')
 args = parser.parse_args()
 
 with open(args.input, 'r', encoding='utf-8') as f:


### PR DESCRIPTION
## Summary
- use `hellPrompts.en.json` as the default path in `sanitize_prompts.py`
- show the new default behaviour in README

## Testing
- `python -m py_compile sanitize_prompts.py translate_prompts.py`


------
https://chatgpt.com/codex/tasks/task_e_684aec071ff0832f81eb39225624ff0d