### PR TITLE
Add share option and offline caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,18 @@ HellPrompts is an open source horror, dystopian and AI writing prompt generator.
 - English and Turkish translations out of the box
 - No build step or server required – just open `index.html`
 - Easily extendable JSON based prompt lists
+- Share prompts using the Web Share API or copy them to your clipboard
+- Works offline thanks to a simple service worker
+
+## Offline usage
+
+The service worker caches all assets and prompt files so you can generate ideas even without an internet connection. Serve the project locally or host it on any static site to enable the PWA features.
 
 
 ## Running locally
 
 1. Clone the repository.
-2. Open `index.html` in your favourite browser. The site works offline.
+2. Serve the folder with a local web server (e.g. `python -m http.server`) and open `index.html`. This registers the service worker for offline use.
 3. Click **Generate Hellprompt** to get a new creepy idea and use the **EN/TR** toggle to switch languages.
 
 ## Customizing prompts

--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@ const promptBox = document.getElementById("promptBox");
 const promptText = document.getElementById("promptText");
 const generateButton = document.getElementById("generateButton");
 const copyButton = document.getElementById("copyButton");
+const shareButton = document.getElementById("shareButton");
 const historyList = document.getElementById("historyList");
 const flameLogo = document.getElementById("flameLogo");
 const historyTitle = document.getElementById("historyTitle");
@@ -14,6 +15,7 @@ const translations = {
     loading: "SUMMONING...",
     loadingPrompts: "LOADING PROMPTS...",
     placeholder: 'Click "Generate" to create a hellish prompt...',
+    share: "Share",
     copy: "Copy",
     copied: "Copied!",
     historyTitle: "PREVIOUS SUMMONINGS",
@@ -24,6 +26,7 @@ const translations = {
     loading: "ÇAĞRILIYOR...",
     loadingPrompts: "İPUÇLARI YÜKLENİYOR...",
     placeholder: 'Şeytani bir komut oluşturmak için "Üret"e tıklayın...',
+    share: "Paylaş",
     copy: "Kopyala",
     copied: "Kopyalandı!",
     historyTitle: "ÖNCEKİ ÇAĞRILMALAR",
@@ -40,6 +43,7 @@ function applyTranslations(lang) {
   loadingText.textContent = t.loading;
   loadingPromptsText.textContent = t.loadingPrompts;
   promptText.textContent = t.placeholder;
+  shareButton.textContent = t.share;
   copyButton.textContent = t.copy;
   historyTitle.textContent = t.historyTitle;
   orderText.textContent = t.order;
@@ -148,11 +152,27 @@ function copyPromptToClipboard() {
   }
 }
 
+function sharePrompt() {
+  const textToShare = promptText.textContent;
+  if (!textToShare || promptText.classList.contains("placeholder-text")) return;
+  if (navigator.share) {
+    navigator
+      .share({ text: textToShare })
+      .catch((err) => console.error("Failed to share: ", err));
+  } else {
+    copyPromptToClipboard();
+  }
+}
+
 // Event listeners
 generateButton.addEventListener("click", generateRandomPrompt);
 copyButton.addEventListener("click", (e) => {
   e.stopPropagation();
   copyPromptToClipboard();
+});
+shareButton.addEventListener("click", (e) => {
+  e.stopPropagation();
+  sharePrompt();
 });
 langToggle.addEventListener("click", (e) => {
   const lang = e.target.dataset.lang;

--- a/index.html
+++ b/index.html
@@ -76,6 +76,7 @@
       </div>
 
       <div class="prompt-box" id="promptBox">
+        <button class="share-button" id="shareButton">Share</button>
         <button class="copy-button" id="copyButton">Copy</button>
         <div class="fire-effect"></div>
         <p class="prompt-text placeholder-text" id="promptText">
@@ -175,5 +176,12 @@
       order all hellprompts via +905539837625
     </p>
     <script src="app.js"></script>
+    <script>
+      if ("serviceWorker" in navigator) {
+        window.addEventListener("load", () => {
+          navigator.serviceWorker.register("service-worker.js");
+        });
+      }
+    </script>
   </body>
 </html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,19 @@
+const CACHE_NAME = 'hellprompts-cache-v1';
+const ASSETS = [
+  '/',
+  'index.html',
+  'styles.css',
+  'app.js',
+  'hellPrompts.en.json',
+  'hellPrompts.tr.json'
+];
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS))
+  );
+});
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request).then((response) => response || fetch(event.request))
+  );
+});

--- a/styles.css
+++ b/styles.css
@@ -130,11 +130,33 @@ body {
   transition: opacity 0.3s ease;
 }
 
+.share-button {
+  position: absolute;
+  top: 10px;
+  right: 70px;
+  background-color: #333;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  padding: 5px 10px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
 .prompt-box:hover .copy-button {
   opacity: 1;
 }
 
+.prompt-box:hover .share-button {
+  opacity: 1;
+}
+
 .copy-button:hover {
+  background-color: #444;
+}
+
+.share-button:hover {
   background-color: #444;
 }
 


### PR DESCRIPTION
## Summary
- add Web Share button with fallback copy
- register a service worker for offline use
- style and translate the share button
- document PWA functionality in the README

## Testing
- `python -m py_compile sanitize_prompts.py translate_prompts.py`

------
https://chatgpt.com/codex/tasks/task_e_684af465285c832f9b75bea5924c30e8