### PR TITLE
Format codebase

### DIFF
--- a/sanitize_prompts.py
+++ b/sanitize_prompts.py
@@ -2,25 +2,27 @@ import argparse
 import json
 import re
 
-CONTROL_CHARS = ''.join(chr(i) for i in range(32)) + chr(127)
-control_re = re.compile('[%s]' % re.escape(CONTROL_CHARS))
+CONTROL_CHARS = "".join(chr(i) for i in range(32)) + chr(127)
+control_re = re.compile("[%s]" % re.escape(CONTROL_CHARS))
 
 parser = argparse.ArgumentParser(
     description="Remove control characters from a JSON list of prompts"
 )
-parser.add_argument('-i', '--input', default='hellPrompts.en.json',
-                    help='Input JSON file')
-parser.add_argument('-o', '--output', default='hellPrompts.en.json',
-                    help='Output JSON file')
+parser.add_argument(
+    "-i", "--input", default="hellPrompts.en.json", help="Input JSON file"
+)
+parser.add_argument(
+    "-o", "--output", default="hellPrompts.en.json", help="Output JSON file"
+)
 args = parser.parse_args()
 
-with open(args.input, 'r', encoding='utf-8') as f:
+with open(args.input, "r", encoding="utf-8") as f:
     data = json.load(f)
 
-cleaned = [control_re.sub('', item) for item in data]
+cleaned = [control_re.sub("", item) for item in data]
 
-with open(args.output, 'w', encoding='utf-8') as f:
+with open(args.output, "w", encoding="utf-8") as f:
     json.dump(cleaned, f, ensure_ascii=False, indent=2)
-    f.write('\n')
+    f.write("\n")
 
-print('Removed control characters from %d prompts.' % len(data))
+print("Removed control characters from %d prompts." % len(data))

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,19 +1,21 @@
-const CACHE_NAME = 'hellprompts-cache-v1';
+const CACHE_NAME = "hellprompts-cache-v1";
 const ASSETS = [
-  '/',
-  'index.html',
-  'styles.css',
-  'app.js',
-  'hellPrompts.en.json',
-  'hellPrompts.tr.json'
+  "/",
+  "index.html",
+  "styles.css",
+  "app.js",
+  "hellPrompts.en.json",
+  "hellPrompts.tr.json",
 ];
-self.addEventListener('install', (event) => {
+self.addEventListener("install", (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS))
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS)),
   );
 });
-self.addEventListener('fetch', (event) => {
+self.addEventListener("fetch", (event) => {
   event.respondWith(
-    caches.match(event.request).then((response) => response || fetch(event.request))
+    caches
+      .match(event.request)
+      .then((response) => response || fetch(event.request)),
   );
 });

--- a/translate_prompts.py
+++ b/translate_prompts.py
@@ -7,17 +7,17 @@ END_INDEX = 3100  # inclusive
 
 translator = Translator()
 
-with open('hellPrompts.en.json', 'r', encoding='utf-8') as f:
+with open("hellPrompts.en.json", "r", encoding="utf-8") as f:
     en_prompts = json.load(f)
 
 # slice prompts
-slice_prompts = en_prompts[START_INDEX:END_INDEX+1]
+slice_prompts = en_prompts[START_INDEX : END_INDEX + 1]
 
 # load existing turkish prompts
-with open('hellPrompts.tr.json', 'r', encoding='utf-8') as f:
+with open("hellPrompts.tr.json", "r", encoding="utf-8") as f:
     tr_prompts = json.load(f)
 
-for idx, text in enumerate(slice_prompts, start=START_INDEX+1):
+for idx, text in enumerate(slice_prompts, start=START_INDEX + 1):
     attempt = 0
     while True:
         try:
@@ -32,6 +32,6 @@ for idx, text in enumerate(slice_prompts, start=START_INDEX+1):
     tr_prompts.append(translated)
     time.sleep(0.3)
 
-with open('hellPrompts.tr.json', 'w', encoding='utf-8') as f:
+with open("hellPrompts.tr.json", "w", encoding="utf-8") as f:
     json.dump(tr_prompts, f, ensure_ascii=False, indent=2)
-    f.write('\n')
+    f.write("\n")


### PR DESCRIPTION
## Summary
- run Prettier on service worker
- format Python scripts with Black

## Testing
- `python -m py_compile sanitize_prompts.py translate_prompts.py`

------
https://chatgpt.com/codex/tasks/task_e_684af57ec670832fb20806070ad7bad8