### PR TITLE
Improve prompt file caching

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,21 +1,54 @@
-const CACHE_NAME = "hellprompts-cache-v1";
-const ASSETS = [
-  "/",
-  "index.html",
-  "styles.css",
-  "app.js",
-  "hellPrompts.en.json",
-  "hellPrompts.tr.json",
-];
+const CACHE_NAME = "hellprompts-cache-v2";
+const ASSETS = ["/", "index.html", "styles.css", "app.js"];
+
+function unique(array) {
+  return Array.from(new Set(array));
+}
+
+async function detectPromptFiles() {
+  try {
+    const res = await fetch("./");
+    const text = await res.text();
+    const regex = /hellPrompts\.[^"'<>]+\.json/g;
+    return unique(text.match(regex) || []);
+  } catch (err) {
+    console.error("Failed to detect prompt files", err);
+    return [];
+  }
+}
+
 self.addEventListener("install", (event) => {
+  self.skipWaiting();
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS)),
+    (async () => {
+      const cache = await caches.open(CACHE_NAME);
+      const promptFiles = await detectPromptFiles();
+      await cache.addAll([...ASSETS, ...promptFiles]);
+    })(),
   );
 });
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
 self.addEventListener("fetch", (event) => {
+  const { request } = event;
+  if (/hellPrompts\.[^/]+\.json$/.test(request.url)) {
+    event.respondWith(
+      caches.match(request).then((cached) => {
+        if (cached) return cached;
+        return fetch(request).then((response) => {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
+          return response;
+        });
+      }),
+    );
+    return;
+  }
+
   event.respondWith(
-    caches
-      .match(event.request)
-      .then((response) => response || fetch(event.request)),
+    caches.match(request).then((response) => response || fetch(request)),
   );
 });


### PR DESCRIPTION
## Summary
- dynamically detect `hellPrompts.<lang>.json` files
- cache discovered prompt files during service worker install
- update cache on new prompt fetches
- claim clients immediately on activation

## Testing
- `prettier --check "**/*.{js,css,html}"`
- `python -m py_compile sanitize_prompts.py translate_prompts.py`
- ❌ `flake8 .` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684af7a92540832f90fe66f7b9e74861