### PR TITLE
Add CLI options for translate script

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,15 @@ python sanitize_prompts.py
 
 ### Translating prompt files
 
-`translate_prompts.py` uses `googletrans` to generate new language files. Example:
+`translate_prompts.py` uses `googletrans` to generate new language files. Pass
+the source file, target language and an optional index range:
 
 ```bash
-python translate_prompts.py
+python translate_prompts.py -i hellPrompts.en.json -l tr -s 1600 -e 3100
 ```
 
-The script reads `hellPrompts.en.json` and writes updates to `hellPrompts.tr.json`.
+This reads `hellPrompts.en.json` and writes translated lines to
+`hellPrompts.tr.json`.
 Install the dependencies first:
 
 ```bash

--- a/translate_prompts.py
+++ b/translate_prompts.py
@@ -1,27 +1,63 @@
+import argparse
 import json
+import os
 import time
 from googletrans import Translator
 
-START_INDEX = 1600
-END_INDEX = 3100  # inclusive
+
+parser = argparse.ArgumentParser(
+    description="Translate prompt files using googletrans"
+)
+parser.add_argument(
+    "-i",
+    "--input",
+    default="hellPrompts.en.json",
+    help="Source JSON file",
+)
+parser.add_argument(
+    "-l",
+    "--lang",
+    default="tr",
+    help="Target language code (e.g. 'tr')",
+)
+parser.add_argument(
+    "-s",
+    "--start",
+    type=int,
+    default=0,
+    help="Start index (0-based)",
+)
+parser.add_argument(
+    "-e",
+    "--end",
+    type=int,
+    help="End index (inclusive, defaults to last prompt)",
+)
+args = parser.parse_args()
+
+
+with open(args.input, "r", encoding="utf-8") as f:
+    en_prompts = json.load(f)
+
+end_index = args.end if args.end is not None else len(en_prompts) - 1
+slice_prompts = en_prompts[args.start : end_index + 1]
+
+base = args.input.rsplit(".", 2)[0]
+output_file = f"{base}.{args.lang}.json"
+
+if os.path.exists(output_file):
+    with open(output_file, "r", encoding="utf-8") as f:
+        translated_prompts = json.load(f)
+else:
+    translated_prompts = []
 
 translator = Translator()
 
-with open("hellPrompts.en.json", "r", encoding="utf-8") as f:
-    en_prompts = json.load(f)
-
-# slice prompts
-slice_prompts = en_prompts[START_INDEX : END_INDEX + 1]
-
-# load existing turkish prompts
-with open("hellPrompts.tr.json", "r", encoding="utf-8") as f:
-    tr_prompts = json.load(f)
-
-for idx, text in enumerate(slice_prompts, start=START_INDEX + 1):
+for idx, text in enumerate(slice_prompts, start=args.start + 1):
     attempt = 0
     while True:
         try:
-            translated = translator.translate(text, src="en", dest="tr").text
+            translated = translator.translate(text, src="en", dest=args.lang).text
             break
         except Exception:
             attempt += 1
@@ -29,9 +65,9 @@ for idx, text in enumerate(slice_prompts, start=START_INDEX + 1):
                 raise
             time.sleep(1)
     print(f"{idx}: {translated}")
-    tr_prompts.append(translated)
+    translated_prompts.append(translated)
     time.sleep(0.3)
 
-with open("hellPrompts.tr.json", "w", encoding="utf-8") as f:
-    json.dump(tr_prompts, f, ensure_ascii=False, indent=2)
+with open(output_file, "w", encoding="utf-8") as f:
+    json.dump(translated_prompts, f, ensure_ascii=False, indent=2)
     f.write("\n")


### PR DESCRIPTION
## Summary
- make `translate_prompts.py` configurable from the command line
- document new options in the README

## Testing
- `python -m py_compile sanitize_prompts.py translate_prompts.py`
- `python translate_prompts.py -h` *(fails: ModuleNotFoundError: No module named 'googletrans')*

------
https://chatgpt.com/codex/tasks/task_e_684af93bc374832fb3473d61f97d703f