### PR TITLE
Add code formatting configs

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, W503

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": false,
+  "printWidth": 80,
+  "trailingComma": "es5",
+  "tabWidth": 2
+}

--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ Contributions are welcome! Please open a pull request with your improvements or 
 python -m py_compile sanitize_prompts.py translate_prompts.py
 ```
 
+Format the code before committing:
+
+```bash
+npx prettier --write .
+flake8 .
+```
+Configuration lives in [.prettierrc](.prettierrc) and [.flake8](.flake8).
+
 ## License
 
 Distributed under the [Apache License 2.0](LICENSE).

--- a/app.js
+++ b/app.js
@@ -56,7 +56,7 @@ function loadPrompts(lang) {
 const generateText = generateButton.querySelector(".generate-text");
 const loadingText = generateButton.querySelector(".loading-text");
 const loadingPromptsText = generateButton.querySelector(
-  ".loading-prompts-text",
+  ".loading-prompts-text"
 );
 
 // Disable button until prompts load
@@ -78,7 +78,7 @@ loadPrompts(currentLang)
 
 // Load prompt history from localStorage and keep the latest five prompts
 let promptHistory = JSON.parse(
-  localStorage.getItem("promptHistory") || "[]",
+  localStorage.getItem("promptHistory") || "[]"
 ).slice(0, 5);
 
 // Display history items

--- a/service-worker.js
+++ b/service-worker.js
@@ -24,7 +24,7 @@ self.addEventListener("install", (event) => {
       const cache = await caches.open(CACHE_NAME);
       const promptFiles = await detectPromptFiles();
       await cache.addAll([...ASSETS, ...promptFiles]);
-    })(),
+    })()
   );
 });
 
@@ -43,12 +43,12 @@ self.addEventListener("fetch", (event) => {
           caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
           return response;
         });
-      }),
+      })
     );
     return;
   }
 
   event.respondWith(
-    caches.match(request).then((response) => response || fetch(request)),
+    caches.match(request).then((response) => response || fetch(request))
   );
 });


### PR DESCRIPTION
## Summary
- add `.flake8` with max line length and ignores
- define Prettier options
- document how to run formatters before committing

## Testing
- `prettier --check "**/*.{js,css,html}"`
- `flake8 .`
- `python -m py_compile sanitize_prompts.py translate_prompts.py`


------
https://chatgpt.com/codex/tasks/task_e_684afa1fd950832f85dc3fe86111628c