### PR TITLE
Fix randomize issue by shuffling prompts on load

### DIFF
--- a/app.js
+++ b/app.js
@@ -69,7 +69,7 @@ let hellPrompts = [];
 applyTranslations(currentLang);
 loadPrompts(currentLang)
   .then((data) => {
-    hellPrompts = data;
+    hellPrompts = data.sort(() => Math.random() - 0.5); // Shuffle once on load
     generateButton.disabled = false;
     loadingPromptsText.style.display = "none";
     generateText.style.display = "block";
@@ -185,7 +185,7 @@ langToggle.addEventListener("click", (e) => {
   generateText.style.display = "none";
   loadPrompts(currentLang)
     .then((data) => {
-      hellPrompts = data;
+      hellPrompts = data.sort(() => Math.random() - 0.5); // Shuffle on lang change
       generateButton.disabled = false;
       loadingPromptsText.style.display = "none";
       generateText.style.display = "block";


### PR DESCRIPTION
## Summary
- shuffle prompt list after loading JSON files

## Testing
- `flake8 .`
- `npx prettier --check "**/*.{js,css,html}"`
- `python -m py_compile sanitize_prompts.py translate_prompts.py`


------
https://chatgpt.com/codex/tasks/task_e_684bfbccb2d8832f86329809b56111e1